### PR TITLE
Include threat rating and category preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 *__pycache__/
+ti_client/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 *.pyc
 *__pycache__/
-ti_client/*

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ with open(file_name, 'wb') as f:
 ## Change Log
 
 ### 0.1.18 (2023-08-23)
-* Add support for the new Threat Rating and Category fiedls on an indicator 
+* Add support for the new Threat Rating and Category fields on an indicator 
 
 ### 0.1.17 (2023-05-26)
 * Allow passing of kwargs into `threat_intel_client.IndicatorClient.get_list()`

--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ with open(file_name, 'wb') as f:
 
 ## Change Log
 
+### 0.1.18 (2023-08-23)
+* Add support for the new Threat Rating and Category fiedls on an indicator 
+
 ### 0.1.17 (2023-05-26)
 * Allow passing of kwargs into `threat_intel_client.IndicatorClient.get_list()`
 

--- a/mandiant_threatintel/threat_intel_client.py
+++ b/mandiant_threatintel/threat_intel_client.py
@@ -619,7 +619,13 @@ class IndicatorsClient:
       An Indicator object (FQDNIndicator, URLIndicator, IPIndicator, or
       MD5Indicator)
     """
-    params = {"include_campaigns": True, "include_reports": True}
+    params = {
+      "include_campaigns": True, 
+      "include_reports": True, 
+      "include_threat_rating": True,
+      "include_misp": False,
+      "include_category": True
+    }
     indicator_api_response = self.get_raw(identifier, params=params)
     return create_indicator(indicator_api_response, self._base_client)
 
@@ -642,6 +648,9 @@ class IndicatorsClient:
         "requests": [{"values": [value]}],
         "include_campaigns": True,
         "include_reports": True,
+        "include_threat_rating": True,
+        "include_misp": False,
+        "include_category": True
     }
     indicator_api_response = self._base_client.make_post_request(
         API_INDICATOR_ROOT, json=request_body
@@ -689,6 +698,9 @@ class IndicatorsClient:
         "limit": page_size,
         "include_campaigns": True,
         "include_reports": True,
+        "include_threat_rating": True,
+        "include_misp": False,
+        "include_category": True
     }
 
     if end_epoch:
@@ -2714,6 +2726,8 @@ class MD5Indicator(APIResponse):
       # },
       "id": {},
       "mscore": {},
+      "threat_rating": {},
+      "category": {},
       "type": {},
       "value": {},
       "is_publishable": {},
@@ -2786,6 +2800,8 @@ class FQDNIndicator(APIResponse):
       # },
       "id": {},
       "mscore": {},
+      "threat_rating": {},
+      "category": {},
       "type": {},
       "value": {},
       "is_publishable": {},
@@ -2847,6 +2863,8 @@ class URLIndicator(APIResponse):
       # },
       "id": {},
       "mscore": {},
+      "threat_rating": {},
+      "category": {},
       "type": {},
       "value": {},
       "is_publishable": {},
@@ -2908,6 +2926,8 @@ class IPIndicator(APIResponse):
       # },
       "id": {},
       "mscore": {},
+      "threat_rating": {},
+      "category": {},
       "type": {},
       "value": {},
       "is_publishable": {},

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup
 
 setup(
     name='mandiant_ti_client',
-    version='0.1.17',
+    version='0.1.18',
     packages=['mandiant_threatintel'],
     url='',
     license='',


### PR DESCRIPTION
Updated threat_intel_client to include support for new indicator request params:

`include_threat_rating` and `include_category`